### PR TITLE
Add expand command

### DIFF
--- a/commands/expand.js
+++ b/commands/expand.js
@@ -1,0 +1,25 @@
+const expand = require('expand-string-professionally')
+
+module.exports = {
+    name: 'expand',
+    description: 'For when a string must be expanded',
+    execute(message, args, newEmbed) {
+        if (args.length === 0)
+            return message.reply(`You didn't give me a string to expand, asshole`);
+
+        let numSpacing = args[0]
+        let messageToProcess = ''
+
+        if (Number.isInteger(numSpacing * 1)) {
+            // Clamp to max value of 16 bit integer, will fix 
+            // expand-string-professionally to handle this later, in 10 years probably
+            messageToProcess = expand(args.splice(1).join(' '), numSpacing > 65536 ? 65536 : numSpacing)
+        } else {
+            messageToProcess = expand(args.join(' '))
+        }
+
+        // Truncate to ensure we do not exceed discord 2000 char limit
+        let truncated = messageToProcess.substring(0, Math.min(2000, messageToProcess.length))
+        return message.channel.send(truncated);
+    },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -500,6 +500,11 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
       "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
+    "expand-string-professionally": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/expand-string-professionally/-/expand-string-professionally-1.0.1.tgz",
+      "integrity": "sha512-EF81OPlkklNuiLcZhcJV4giRSN07MeoJMenCGbVft6i0tU9rtsynDowSrE8XS2RQSJ312miqnhZNStvuGG/VWw=="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "discord.js": "^11.5.1",
+    "expand-string-professionally": "^1.0.1",
     "images-scraper": "^2.0.11",
     "jikanjs": "^0.7.0",
     "request": "^2.88.0",


### PR DESCRIPTION
The expand command takes in a message, and adds spaces to it and sends it back to the current channel.

The expand command defaults to 1 space, however, a number of spaces can be specified.

Example usage:

!expand test -> 't e s t'

!expand 2 test -> 't&nbsp;&nbsp;e&nbsp;&nbsp;s&nbsp;&nbsp;t'